### PR TITLE
Update EE01_ESTONIA.m3u

### DIFF
--- a/EE01_ESTONIA.m3u
+++ b/EE01_ESTONIA.m3u
@@ -2,11 +2,14 @@
 #EXTINF:-1 tvg-name="***************** ESTONIA  ***********",***************** ESTONIA  ***********
 https://errstreams4.cdn.eurovisioncdn.net/live/etvpluss-kval2/index.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="ETV+" tvg-logo="https://i.imgur.com/L8fGd9d.png" group-title="ESTONIA",ETV+
-https://errstreams4.cdn.eurovisioncdn.net/live/etvpluss-kval2/index.m3u8
+# https://errstreams4.cdn.eurovisioncdn.net/live/etvpluss-kval2/index.m3u8
+http://sb.err.ee/live/etvpluss.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="ETV" tvg-logo="https://i.imgur.com/SAOGSmL.png" group-title="ESTONIA",ETV
-https://errstreams4.cdn.eurovisioncdn.net/live/etv-kval2/index.m3u8
+# https://errstreams4.cdn.eurovisioncdn.net/live/etv-kval2/index.m3u8
+http://sb.err.ee/live/etv.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="ETV 2" tvg-logo="https://i.imgur.com/wY6Pz37.png" group-title="ESTONIA",ETV 2
-https://errstreams4.cdn.eurovisioncdn.net/live/etv2-kval2/index.m3u8
+# https://errstreams4.cdn.eurovisioncdn.net/live/etv2-kval2/index.m3u8
+http://sb.err.ee/live/etv2.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="Riigikogu" tvg-logo="https://i.imgur.com/xuySaSN.png" group-title="ESTONIA",Riigikogu
 https://riigikogu.babahhcdn.com/bb1027/smil:riigikogu_ch1.smil/playlist.m3u8
 #EXTINF:-1 tvg-id="" tvg-name="Taevas TV 7 " tvg-logo="https://i.imgur.com/FaQQdzz.png" group-title="ESTONIA",Taevas TV 7 


### PR DESCRIPTION
Updated ETV, ETV2, ETV+ links with local ones, so they play also geoblocked TV-shows, when watching in Estonia. Existing links do not show geoblocked TV-shows and are just commented out. Tested locally with mediaplayer, working.